### PR TITLE
Fix validation unknown type errors

### DIFF
--- a/lib/validation/bundlers/fieldsVB.ts
+++ b/lib/validation/bundlers/fieldsVB.ts
@@ -26,7 +26,7 @@ export class FieldsVB extends ValidationBundler<Field[]> {
     addFormats(this.schemaValidator);
   }
 
-  public getValidations(fields: Field[]): Validation<Field>[] {
+  public getValidations(fields: Field[]): Validation<unknown>[] {
     let validations: Validation<Field>[] = [];
 
     if (fields != null) {

--- a/lib/validation/bundlers/submissionRequirementVB.ts
+++ b/lib/validation/bundlers/submissionRequirementVB.ts
@@ -17,7 +17,7 @@ export class SubmissionRequirementVB extends ValidationBundler<SubmissionRequire
     super(parentTag, 'submission_requirements');
   }
 
-  public getValidations(srs: SubmissionRequirement[]): Validation<SubmissionRequirement>[] {
+  public getValidations(srs: SubmissionRequirement[]): Validation<unknown>[] {
     let validations: Validation<SubmissionRequirement>[] = [];
     if (srs != null && srs.length > 0) {
       for (let srInd = 0; srInd < srs.length; srInd++) {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix tsc compilation errors.

- **What is the current behavior?** (You can also link to an open issue here)

I get the following tsc compilation errors when using the npm package from my package and trying to compile.

```
src/lib/node_modules/@sphereon/pe-js/build/main/lib/validation/bundlers/fieldsVB.d.ts:14:5 - error TS2416: Property 'getValidations' in type 'FieldsVB' is not assignable to the same property in base type 'ValidationBundler<Field[]>'.
  Type '(fields: Field[]) => Validation<Field>[]' is not assignable to type '(t: Field[] | Field[][]) => Validation<unknown>[]'.
    Type 'Validation<Field>[]' is not assignable to type 'Validation<unknown>[]'.
      Type 'Validation<Field>' is not assignable to type 'Validation<unknown>'.
        Types of property 'predicate' are incompatible.
          Type 'ValidationPredicate<Field>' is not assignable to type 'ValidationPredicate<unknown>'.
            Type 'unknown' is not assignable to type 'Field'.

14     getValidations(fields: Field[]): Validation<Field>[];
       ~~~~~~~~~~~~~~

src/lib/node_modules/@sphereon/pe-js/build/main/lib/validation/bundlers/submissionRequirementVB.d.ts:13:5 - error TS2416: Property 'getValidations' in type 'SubmissionRequirementVB' is not assignable to the same property in base type 'ValidationBundler<SubmissionRequirement>'.
  Type '(srs: SubmissionRequirement[]) => Validation<SubmissionRequirement>[]' is not assignable to type '(t: SubmissionRequirement | SubmissionRequirement[]) => Validation<unknown>[]'.
    Type 'Validation<SubmissionRequirement>[]' is not assignable to type 'Validation<unknown>[]'.
      Type 'Validation<SubmissionRequirement>' is not assignable to type 'Validation<unknown>'.
        Types of property 'predicate' are incompatible.
          Type 'ValidationPredicate<SubmissionRequirement>' is not assignable to type 'ValidationPredicate<unknown>'.
            Type 'unknown' is not assignable to type 'SubmissionRequirement'.

13     getValidations(srs: SubmissionRequirement[]): Validation<SubmissionRequirement>[];
       ~~~~~~~~~~~~~~
```

- **What is the new behavior (if this is a feature change)?**

No tsc compilation errors

- **Other information**:

My tsconfig.json is as follows:

```
{
  "compilerOptions": {
    "module": "commonjs",
    "target": "es6",
    "moduleResolution": "node",
    "resolveJsonModule": true,
    "experimentalDecorators": true,
    "outDir": "./build/web",
    "sourceMap": false,
    "strict": true
  },
  "include": ["."]
}
```