### PR TITLE
Removed "import { URL } from 'url'" to allow poly-fixing

### DIFF
--- a/lib/validation/bundlers/inputDescriptorsVB.ts
+++ b/lib/validation/bundlers/inputDescriptorsVB.ts
@@ -1,4 +1,3 @@
-
 import { InputDescriptor, Schema } from '@sphereon/pe-models';
 
 import { Validation, ValidationPredicate } from '../core';

--- a/lib/validation/bundlers/inputDescriptorsVB.ts
+++ b/lib/validation/bundlers/inputDescriptorsVB.ts
@@ -1,4 +1,3 @@
-import { URL } from 'url';
 
 import { InputDescriptor, Schema } from '@sphereon/pe-models';
 


### PR DESCRIPTION
For React Native we need to polyfix URL with a working version. This won't work when using an explicit import.
(This is an impediment, now I have to manually fix this in node_modules every time I did a yarn add)