### PR TITLE
ESSIFI-160: json path for methods selectFrom, presentationFrom, and v…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 Fixed json path issue in library responses.
 
 - Updated:
+  - added verifiableCredential (list) to return params of evaluatePresentation 
+  - added verifiableCredential (list) to return params of evaluateCredentials
   - selectFrom response changed to have "verifiableCredential" instead of "selectableVerifiableCredential"
   - json path of the verifiableCredentials, now start at presentation object root
+  - renamed matches in submissionRequirementMatches to vc_path
 
 ## v0.5.0 - 2021-11-29
 Refactor verifiable presentation support using callbacks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Release Notes
+## v5.0.1 - 2021-12-03
+Fixed json path issue in library responses.
+
+- Updated:
+  - selectFrom response changed to have "verifiableCredential" instead of "selectableVerifiableCredential"
+  - json path of the verifiableCredentials, now start at presentation object root
+
 ## v0.5.0 - 2021-11-29
 Refactor verifiable presentation support using callbacks
 

--- a/README.md
+++ b/README.md
@@ -453,6 +453,7 @@ interface EvaluationResults {
   value?: PresentationSubmission;
   warnings?: string[];
   errors?: Error[];
+  verifiableCredential: VerifiableCredential[];
 }
 ```
 
@@ -514,7 +515,7 @@ interface SubmissionRequirementMatch {
   min?: number;
   count?: number;
   max?: number;
-  matches: string[];
+  vc_path: string[];
   from?: string[];
   from_nested?: SubmissionRequirementMatch[]; // VerifiableCredential Address
 }

--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ interface SelectResults {
   /**
    * All matched/selectable credentials
    */
-  selectableVerifiableCredentials?: VerifiableCredential[];
+  verifiableCredential?: VerifiableCredential[];
   /**
    * Following are indexes of the verifiableCredentials passed to the selectFrom method that have been selected.
    */

--- a/lib/evaluation/core/selectResults.ts
+++ b/lib/evaluation/core/selectResults.ts
@@ -18,7 +18,7 @@ export interface SelectResults {
   /**
    * All matched/selectable credentials
    */
-  selectableVerifiableCredentials?: VerifiableCredential[];
+  verifiableCredential?: VerifiableCredential[];
   /**
    * Following are indexes of the verifiableCredentials passed to the selectFrom method that have been selected.
    */

--- a/lib/evaluation/core/submissionRequirementMatch.ts
+++ b/lib/evaluation/core/submissionRequirementMatch.ts
@@ -6,7 +6,7 @@ export interface SubmissionRequirementMatch {
   min?: number;
   count?: number;
   max?: number;
-  matches: string[];
+  vc_path: string[];
   from?: string[];
   from_nested?: SubmissionRequirementMatch[];
 }

--- a/lib/evaluation/evaluationClientWrapper.ts
+++ b/lib/evaluation/evaluationClientWrapper.ts
@@ -187,7 +187,7 @@ export class EvaluationClientWrapper {
     limitDisclosureSignatureSuites?: string[]
   ): EvaluationResults {
     this._client.evaluate(pd, vcs, holderDids, limitDisclosureSignatureSuites);
-    const result: EvaluationResults = {};
+    const result: EvaluationResults = { verifiableCredential: [...vcs] };
     result.warnings = this.formatNotInfo(Status.WARN);
     result.errors = this.formatNotInfo(Status.ERROR);
     if (this._client.presentationSubmission?.descriptor_map.length) {
@@ -199,8 +199,9 @@ export class EvaluationClientWrapper {
           );
       }
       this._client.presentationSubmission.descriptor_map.splice(0, len); // cut the array and leave only the non-empty values
-      result.value = this._client.presentationSubmission;
+      result.value = JSON.parse(JSON.stringify(this._client.presentationSubmission));
     }
+    this.updatePresentationSubmissionPathToAlias('verifiableCredential', result.value);
     return result;
   }
 
@@ -455,10 +456,16 @@ export class EvaluationClientWrapper {
     }
   }
 
-  private updatePresentationSubmissionPathToAlias(alias: string) {
-    this._client.presentationSubmission.descriptor_map.forEach((d) => {
-      this.replacePathWithAlias(d, alias);
-    });
+  private updatePresentationSubmissionPathToAlias(alias: string, presentationSubmission?: PresentationSubmission) {
+    if (presentationSubmission) {
+      presentationSubmission.descriptor_map.forEach((d) => {
+        this.replacePathWithAlias(d, alias);
+      });
+    } else {
+      this._client.presentationSubmission.descriptor_map.forEach((d) => {
+        this.replacePathWithAlias(d, alias);
+      });
+    }
   }
 
   private replacePathWithAlias(descriptor: Descriptor, alias: string) {

--- a/lib/evaluation/evaluationClientWrapper.ts
+++ b/lib/evaluation/evaluationClientWrapper.ts
@@ -58,7 +58,7 @@ export class EvaluationClientWrapper {
         errors: errors,
         matches: [...matchSubmissionRequirements],
         areRequiredCredentialsPresent: Status.INFO,
-        selectableVerifiableCredentials: [...credentials],
+        verifiableCredential: [...credentials],
         warnings,
       };
     } else {
@@ -74,7 +74,7 @@ export class EvaluationClientWrapper {
         errors: errors,
         matches: [...matchSubmissionRequirements],
         areRequiredCredentialsPresent: Status.INFO,
-        selectableVerifiableCredentials: [...credentials],
+        verifiableCredential: [...credentials],
         warnings,
       };
     }
@@ -83,7 +83,7 @@ export class EvaluationClientWrapper {
     selectResults.areRequiredCredentialsPresent = this.determineAreRequiredCredentialsPresent(selectResults?.matches);
     this.remapMatches(selectResults, verifiableCredentials);
     selectResults.matches?.forEach((m) => {
-      this.updateSubmissionRequirementMatchPathToAlias(m, 'selectableVerifiableCredentials');
+      this.updateSubmissionRequirementMatchPathToAlias(m, 'verifiableCredential');
     });
     return selectResults;
   }
@@ -92,7 +92,7 @@ export class EvaluationClientWrapper {
     selectResults.matches?.forEach((srm) => {
       srm.matches.forEach((match, index, matches) => {
         const vc = jp.query(verifiableCredentials, match)[0];
-        const newIndex = selectResults.selectableVerifiableCredentials?.findIndex((svc) => svc.id === vc.id);
+        const newIndex = selectResults.verifiableCredential?.findIndex((svc) => svc.id === vc.id);
         matches[index] = `$[${newIndex}]`;
       });
       srm.name;
@@ -402,7 +402,7 @@ export class EvaluationClientWrapper {
     verifiableCredentials: VerifiableCredential[]
   ) {
     if (selectResults) {
-      selectResults.selectableVerifiableCredentials?.forEach((selectableCredential: VerifiableCredential) => {
+      selectResults.verifiableCredential?.forEach((selectableCredential: VerifiableCredential) => {
         const foundIndex: number = verifiableCredentials.findIndex(
           (verifiableCredential) => selectableCredential.id === verifiableCredential.id
         );

--- a/lib/evaluation/evaluationResults.ts
+++ b/lib/evaluation/evaluationResults.ts
@@ -1,9 +1,11 @@
 import { PresentationSubmission } from '@sphereon/pe-models';
 
 import { Checked } from '../ConstraintUtils';
+import { VerifiableCredential } from '../types';
 
 export interface EvaluationResults {
   value?: PresentationSubmission;
   warnings?: Checked[];
   errors?: Checked[];
+  verifiableCredential: VerifiableCredential[];
 }

--- a/test/evaluation/EvaluationClientWrapperData.ts
+++ b/test/evaluation/EvaluationClientWrapperData.ts
@@ -172,7 +172,7 @@ export class EvaluationClientWrapperData {
           {
             format: 'ldp_vc',
             id: '867bfe7a-5b91-46b2-9ba4-70028b8d9cc8',
-            path: '$[0]',
+            path: '$.verifiableCredential[0]',
           },
         ],
       }),
@@ -189,7 +189,7 @@ export class EvaluationClientWrapperData {
           {
             format: 'ldp_vc',
             id: '867bfe7a-5b91-46b2-9ba4-70028b8d9cc8',
-            path: '$[0]',
+            path: '$.verifiableCredential[0]',
           },
         ],
       }),
@@ -253,7 +253,7 @@ export class EvaluationClientWrapperData {
         {
           name: 'test',
           rule: Rules.All,
-          vc_path: ['$[0]'],
+          vc_path: ['$.verifiableCredential[0]'],
         },
       ],
     };

--- a/test/evaluation/EvaluationClientWrapperData.ts
+++ b/test/evaluation/EvaluationClientWrapperData.ts
@@ -253,7 +253,7 @@ export class EvaluationClientWrapperData {
         {
           name: 'test',
           rule: Rules.All,
-          matches: ['$[0]'],
+          vc_path: ['$[0]'],
         },
       ],
     };

--- a/test/evaluation/EvaluationClientWrapperData.ts
+++ b/test/evaluation/EvaluationClientWrapperData.ts
@@ -225,7 +225,7 @@ export class EvaluationClientWrapperData {
   public getSelectResults(): SelectResults {
     return {
       areRequiredCredentialsPresent: Status.INFO,
-      selectableVerifiableCredentials: [
+      verifiableCredential: [
         {
           id: 'CredentialID2021110405',
           credentialStatus: {

--- a/test/evaluation/EvaluationClientWrapperData.ts
+++ b/test/evaluation/EvaluationClientWrapperData.ts
@@ -75,7 +75,7 @@ export class EvaluationClientWrapperData {
         {
           id: 'Educational transcripts',
           format: 'ldp_vc',
-          path: '$[0]',
+          path: '$.verifiableCredential[0]',
         },
       ],
     };

--- a/test/evaluation/check-scenario-1.spec.ts
+++ b/test/evaluation/check-scenario-1.spec.ts
@@ -204,8 +204,8 @@ describe('1st scenario', () => {
     );
     expect(selectFromResult.matches?.length).toEqual(2);
     expect(selectFromResult.matches).toEqual([
-      { rule: 'all', matches: ['$.verifiableCredential[0]'], name: 'e73646de-43e2-4d72-ba4f-090d01c11eac' },
-      { rule: 'all', matches: ['$.verifiableCredential[0]'], name: '867bfe7a-5b91-46b2-9ba4-70028b8d9cc8' },
+      { rule: 'all', vc_path: ['$.verifiableCredential[0]'], name: 'e73646de-43e2-4d72-ba4f-090d01c11eac' },
+      { rule: 'all', vc_path: ['$.verifiableCredential[0]'], name: '867bfe7a-5b91-46b2-9ba4-70028b8d9cc8' },
     ]);
     expect(selectFromResult.verifiableCredential?.length).toEqual(1);
 

--- a/test/evaluation/check-scenario-1.spec.ts
+++ b/test/evaluation/check-scenario-1.spec.ts
@@ -204,10 +204,10 @@ describe('1st scenario', () => {
     );
     expect(selectFromResult.matches?.length).toEqual(2);
     expect(selectFromResult.matches).toEqual([
-      { rule: 'all', matches: ['$.selectableVerifiableCredentials[0]'], name: 'e73646de-43e2-4d72-ba4f-090d01c11eac' },
-      { rule: 'all', matches: ['$.selectableVerifiableCredentials[0]'], name: '867bfe7a-5b91-46b2-9ba4-70028b8d9cc8' },
+      { rule: 'all', matches: ['$.verifiableCredential[0]'], name: 'e73646de-43e2-4d72-ba4f-090d01c11eac' },
+      { rule: 'all', matches: ['$.verifiableCredential[0]'], name: '867bfe7a-5b91-46b2-9ba4-70028b8d9cc8' },
     ]);
-    expect(selectFromResult.selectableVerifiableCredentials?.length).toEqual(1);
+    expect(selectFromResult.verifiableCredential?.length).toEqual(1);
 
     /**
      * Base on the selectFrom result, now Alice knows what to send, so she will call the presentationFrom with the right VerifiableCredential (index #2)

--- a/test/evaluation/check-scenario-1.spec.ts
+++ b/test/evaluation/check-scenario-1.spec.ts
@@ -204,8 +204,8 @@ describe('1st scenario', () => {
     );
     expect(selectFromResult.matches?.length).toEqual(2);
     expect(selectFromResult.matches).toEqual([
-      { rule: 'all', matches: ['$[0]'], name: 'e73646de-43e2-4d72-ba4f-090d01c11eac' },
-      { rule: 'all', matches: ['$[0]'], name: '867bfe7a-5b91-46b2-9ba4-70028b8d9cc8' },
+      { rule: 'all', matches: ['$.selectableVerifiableCredentials[0]'], name: 'e73646de-43e2-4d72-ba4f-090d01c11eac' },
+      { rule: 'all', matches: ['$.selectableVerifiableCredentials[0]'], name: '867bfe7a-5b91-46b2-9ba4-70028b8d9cc8' },
     ]);
     expect(selectFromResult.selectableVerifiableCredentials?.length).toEqual(1);
 

--- a/test/evaluation/core/submissionRequirementMatch.spec.ts
+++ b/test/evaluation/core/submissionRequirementMatch.spec.ts
@@ -7,11 +7,11 @@ describe('submissionRequirementMatch', () => {
     const submissionRequirementMatch: SubmissionRequirementMatch = {
       name: 'test srm',
       rule: Rules.All,
-      matches: ['$.verifiableCredential[1]'],
+      vc_path: ['$.verifiableCredential[1]'],
       from: ['A'],
     };
     expect(submissionRequirementMatch.from).toContain('A');
     expect(submissionRequirementMatch.rule).toBe(Rules.All);
-    expect(submissionRequirementMatch.matches[0]).toBe('$.verifiableCredential[1]');
+    expect(submissionRequirementMatch.vc_path[0]).toBe('$.verifiableCredential[1]');
   });
 });

--- a/test/evaluation/evaluationClientWrapper.spec.ts
+++ b/test/evaluation/evaluationClientWrapper.spec.ts
@@ -258,12 +258,12 @@ describe('evaluate', () => {
           {
             format: 'ldp_vc',
             id: 'Educational transcripts 1',
-            path: '$[1]',
+            path: '$.verifiableCredential[1]',
           },
           {
             format: 'ldp_vc',
             id: 'Educational transcripts 2',
-            path: '$[2]',
+            path: '$.verifiableCredential[2]',
           },
         ],
       })
@@ -291,7 +291,7 @@ describe('evaluate', () => {
     expect(result).toEqual(
       expect.objectContaining({
         definition_id: '32f54163-7166-48f1-93d8-ff217bdb0653',
-        descriptor_map: [{ format: 'ldp_vc', id: 'Educational transcripts 1', path: '$[0]' }],
+        descriptor_map: [{ format: 'ldp_vc', id: 'Educational transcripts 1', path: '$.verifiableCredential[0]' }],
       })
     );
   });
@@ -322,12 +322,12 @@ describe('evaluate', () => {
           {
             format: 'ldp_vc',
             id: 'Educational transcripts 1',
-            path: '$[0]',
+            path: '$.verifiableCredential[0]',
           },
           {
             format: 'ldp_vc',
             id: 'Educational transcripts 2',
-            path: '$[1]',
+            path: '$.verifiableCredential[1]',
           },
         ],
       })

--- a/test/evaluation/evaluationClientWrapper.spec.ts
+++ b/test/evaluation/evaluationClientWrapper.spec.ts
@@ -32,7 +32,8 @@ describe('evaluate', () => {
     );
     expect(evaluationClient.results[0]).toEqual(evaluationClientWrapperData.getInputDescriptorsDoesNotMatchResult0());
     expect(evaluationClient.results[5]).toEqual(evaluationClientWrapperData.getInputDescriptorsDoesNotMatchResult3());
-    expect(evaluationResults).toEqual(evaluationClientWrapperData.getError());
+    expect(evaluationResults.errors).toEqual(evaluationClientWrapperData.getError().errors);
+    expect(evaluationResults.warnings?.length).toEqual(0);
   });
 
   it("should return ok if uri in vp matches at least one of input_descriptor's uris", function () {
@@ -51,7 +52,9 @@ describe('evaluate', () => {
     );
     const errorResults = evaluationClient.results.filter((result) => result.status === Status.ERROR);
     expect(errorResults.length).toEqual(0);
-    expect(evaluationResults).toEqual(evaluationClientWrapperData.getSuccess());
+    expect(evaluationResults.value).toEqual(evaluationClientWrapperData.getSuccess().value);
+    expect(evaluationResults.errors?.length).toEqual(0);
+    expect(evaluationResults.warnings?.length).toEqual(0);
   });
 
   it("should return error if uri in verifiableCredential doesn't match", function () {
@@ -74,7 +77,8 @@ describe('evaluate', () => {
     expect(evaluationClient.results[5]).toEqual(
       evaluationClientWrapperData.getUriInVerifiableCredentialDoesNotMatchResult3()
     );
-    expect(evaluationResults).toEqual(evaluationClientWrapperData.getError());
+    expect(evaluationResults.errors).toEqual(evaluationClientWrapperData.getError().errors);
+    expect(evaluationResults.warnings?.length).toEqual(0);
   });
 
   it("should return error if all the uris in vp don't match at least one of input_descriptor's uris", function () {
@@ -93,7 +97,8 @@ describe('evaluate', () => {
     );
     const errorResults = evaluationClient.results.filter((result) => result.status === Status.ERROR);
     expect(errorResults.length).toEqual(2);
-    expect(evaluationResults).toEqual(evaluationClientWrapperData.getError());
+    expect(evaluationResults.errors).toEqual(evaluationClientWrapperData.getError().errors);
+    expect(evaluationResults.warnings?.length).toEqual(0);
   });
 
   it("should return ok if all the uris in vp match at least one of input_descriptor's uris", function () {
@@ -112,7 +117,9 @@ describe('evaluate', () => {
     );
     const errorResults = evaluationClient.results.filter((result) => result.status === Status.ERROR);
     expect(errorResults.length).toEqual(0);
-    expect(evaluationResults).toEqual(evaluationClientWrapperData.getSuccess());
+    expect(evaluationResults.value).toEqual(evaluationClientWrapperData.getSuccess().value);
+    expect(evaluationResults.errors?.length).toEqual(0);
+    expect(evaluationResults.warnings?.length).toEqual(0);
   });
 
   it('should return info if limit_disclosure deletes the etc field', function () {
@@ -129,7 +136,9 @@ describe('evaluate', () => {
       LIMIT_DISCLOSURE_SIGNATURE_SUITES
     );
     expect(evaluationClient.verifiableCredential[0].credentialSubject['etc']).toBeUndefined();
-    expect(evaluationResults).toEqual(evaluationClientWrapperData.getSuccess());
+    expect(evaluationResults.value).toEqual(evaluationClientWrapperData.getSuccess().value);
+    expect(evaluationResults.errors).toEqual(evaluationClientWrapperData.getSuccess().errors);
+    expect(evaluationResults.warnings?.length).toEqual(0);
   });
 
   it('should return info if limit_disclosure does not delete the etc field', function () {
@@ -147,7 +156,9 @@ describe('evaluate', () => {
       LIMIT_DISCLOSURE_SIGNATURE_SUITES
     );
     expect(evaluationClient.verifiableCredential[0].credentialSubject['etc']).toEqual('etc');
-    expect(evaluationResults).toEqual(evaluationClientWrapperData.getSuccess());
+    expect(evaluationResults.value).toEqual(evaluationClientWrapperData.getSuccess().value);
+    expect(evaluationResults.errors).toEqual(evaluationClientWrapperData.getSuccess().errors);
+    expect(evaluationResults.warnings?.length).toEqual(0);
   });
 
   it('should return warn if limit_disclosure deletes the etc field', function () {
@@ -165,7 +176,9 @@ describe('evaluate', () => {
       LIMIT_DISCLOSURE_SIGNATURE_SUITES
     );
     expect(evaluationClient.verifiableCredential[0].credentialSubject['etc']).toBeUndefined();
-    expect(evaluationResults).toEqual(evaluationClientWrapperData.getWarn());
+    expect(evaluationResults.value).toEqual(evaluationClientWrapperData.getWarn().value);
+    expect(evaluationResults.errors?.length).toEqual(0);
+    expect(evaluationResults.warnings).toEqual(evaluationClientWrapperData.getWarn().warnings);
   });
 
   it("should return ok if vc[0] doesn't have the birthPlace field", function () {
@@ -183,7 +196,9 @@ describe('evaluate', () => {
       LIMIT_DISCLOSURE_SIGNATURE_SUITES
     );
     expect(evaluationClient.verifiableCredential[0].credentialSubject['birthPlace']).toBeUndefined();
-    expect(evaluationResults).toEqual(evaluationClientWrapperData.getSuccess());
+    expect(evaluationResults.value).toEqual(evaluationClientWrapperData.getSuccess().value);
+    expect(evaluationResults.errors?.length).toEqual(0);
+    expect(evaluationResults.warnings?.length).toEqual(0);
   });
 
   it("should return ok if vc[0] doesn't have the etc field", function () {
@@ -203,7 +218,9 @@ describe('evaluate', () => {
       LIMIT_DISCLOSURE_SIGNATURE_SUITES
     );
     expect(evaluationClient.verifiableCredential[0].credentialSubject['etc']).toBeUndefined();
-    expect(evaluationResults).toEqual(evaluationClientWrapperData.getSuccess());
+    expect(evaluationResults.value).toEqual(evaluationClientWrapperData.getSuccess().value);
+    expect(evaluationResults.errors?.length).toEqual(0);
+    expect(evaluationResults.warnings?.length).toEqual(0);
   });
 
   it('Evaluate submission requirements all rule', () => {

--- a/test/evaluation/evaluationClientWrapper.spec.ts
+++ b/test/evaluation/evaluationClientWrapper.spec.ts
@@ -339,7 +339,7 @@ describe('evaluate', () => {
       selectResults,
       evaluationClientWrapperData.getVerifiableCredential()
     );
-    const verifiableCredential = selectResults.selectableVerifiableCredentials![0];
+    const verifiableCredential = selectResults.verifiableCredential![0];
     const indexInResults = selectResults.vcIndexes![0];
     expect(verifiableCredential.id).toEqual(evaluationClientWrapperData.getVerifiableCredential()[indexInResults].id);
   });

--- a/test/evaluation/selectFrom.spec.ts
+++ b/test/evaluation/selectFrom.spec.ts
@@ -119,7 +119,7 @@ describe('selectFrom tests', () => {
       matches: [
         {
           from: ['A'],
-          matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
+          vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
           name: 'Submission of educational transcripts',
           rule: 'all',
         },
@@ -297,7 +297,7 @@ describe('selectFrom tests', () => {
       matches: [
         {
           from: ['B'],
-          matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
+          vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
           min: 2,
           name: 'Submission of educational transcripts',
           rule: 'pick',
@@ -456,19 +456,19 @@ describe('selectFrom tests', () => {
           from_nested: [
             {
               from: ['A'],
-              matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
+              vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
               from: ['B'],
-              matches: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
+              vc_path: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
             },
           ],
-          matches: [],
+          vc_path: [],
           name: '32f54163-7166-48f1-93d8-ff217bdb0653',
           rule: 'pick',
         },
@@ -646,7 +646,7 @@ describe('selectFrom tests', () => {
       matches: [
         {
           from: ['B'],
-          matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
+          vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
           max: 2,
           name: 'Submission of educational transcripts',
           rule: 'pick',
@@ -804,19 +804,19 @@ describe('selectFrom tests', () => {
           from_nested: [
             {
               from: ['A'],
-              matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
+              vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
               from: ['B'],
-              matches: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
+              vc_path: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
             },
           ],
-          matches: [],
+          vc_path: [],
           name: '32f54163-7166-48f1-93d8-ff217bdb0653',
           rule: 'all',
         },
@@ -996,19 +996,19 @@ describe('selectFrom tests', () => {
           from_nested: [
             {
               from: ['A'],
-              matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
+              vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
               from: ['B'],
-              matches: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
+              vc_path: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
             },
           ],
-          matches: [],
+          vc_path: [],
           min: 1,
           name: '32f54163-7166-48f1-93d8-ff217bdb0653',
           rule: 'pick',
@@ -1189,19 +1189,19 @@ describe('selectFrom tests', () => {
           from_nested: [
             {
               from: ['A'],
-              matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
+              vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
               from: ['B'],
-              matches: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
+              vc_path: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
             },
           ],
-          matches: [],
+          vc_path: [],
           max: 2,
           name: '32f54163-7166-48f1-93d8-ff217bdb0653',
           rule: 'pick',
@@ -1380,7 +1380,7 @@ describe('selectFrom tests', () => {
       matches: [
         {
           from: ['B'],
-          matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
+          vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
           min: 3,
           name: 'Submission of educational transcripts',
           rule: 'pick',
@@ -1536,7 +1536,7 @@ describe('selectFrom tests', () => {
       matches: [
         {
           from: ['B'],
-          matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
+          vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
           max: 1,
           name: 'Submission of educational transcripts',
           rule: 'pick',
@@ -1693,7 +1693,7 @@ describe('selectFrom tests', () => {
         {
           count: 1,
           from: ['B'],
-          matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
+          vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
           name: 'Submission of educational transcripts',
           rule: 'pick',
         },
@@ -1848,7 +1848,7 @@ describe('selectFrom tests', () => {
       matches: [
         {
           from: ['B'],
-          matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
+          vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
           name: 'Submission of educational transcripts',
           rule: 'all',
         },
@@ -2005,19 +2005,19 @@ describe('selectFrom tests', () => {
           from_nested: [
             {
               from: ['A'],
-              matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
+              vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
               from: ['B'],
-              matches: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
+              vc_path: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
             },
           ],
-          matches: [],
+          vc_path: [],
           min: 3,
           name: '32f54163-7166-48f1-93d8-ff217bdb0653',
           rule: 'pick',
@@ -2197,19 +2197,19 @@ describe('selectFrom tests', () => {
           from_nested: [
             {
               from: ['A'],
-              matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
+              vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
               from: ['B'],
-              matches: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
+              vc_path: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
             },
           ],
-          matches: [],
+          vc_path: [],
           name: '32f54163-7166-48f1-93d8-ff217bdb0653',
           rule: 'pick',
           max: 1,
@@ -2300,7 +2300,7 @@ describe('selectFrom tests', () => {
     expect(result!.matches![0]).toEqual({
       name: "EU Driver's License",
       rule: 'all',
-      matches: ['$.verifiableCredential[0]'],
+      vc_path: ['$.verifiableCredential[0]'],
     });
   });
 

--- a/test/evaluation/selectFrom.spec.ts
+++ b/test/evaluation/selectFrom.spec.ts
@@ -119,16 +119,12 @@ describe('selectFrom tests', () => {
       matches: [
         {
           from: ['A'],
-          matches: [
-            '$.selectableVerifiableCredentials[0]',
-            '$.selectableVerifiableCredentials[1]',
-            '$.selectableVerifiableCredentials[2]',
-          ],
+          matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
           name: 'Submission of educational transcripts',
           rule: 'all',
         },
       ],
-      selectableVerifiableCredentials: [
+      verifiableCredential: [
         {
           comment: 'IN REALWORLD VPs, THIS WILL BE A BIG UGLY OBJECT INSTEAD OF THE DECODED JWT PAYLOAD THAT FOLLOWS',
           vc: {
@@ -301,13 +297,13 @@ describe('selectFrom tests', () => {
       matches: [
         {
           from: ['B'],
-          matches: ['$.selectableVerifiableCredentials[0]', '$.selectableVerifiableCredentials[1]'],
+          matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
           min: 2,
           name: 'Submission of educational transcripts',
           rule: 'pick',
         },
       ],
-      selectableVerifiableCredentials: [
+      verifiableCredential: [
         {
           '@context': 'https://business-standards.org/schemas/employment-history.json',
           credentialSubject: {
@@ -460,18 +456,14 @@ describe('selectFrom tests', () => {
           from_nested: [
             {
               from: ['A'],
-              matches: [
-                '$.selectableVerifiableCredentials[0]',
-                '$.selectableVerifiableCredentials[1]',
-                '$.selectableVerifiableCredentials[2]',
-              ],
+              matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
               from: ['B'],
-              matches: ['$.selectableVerifiableCredentials[1]', '$.selectableVerifiableCredentials[2]'],
+              matches: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
             },
@@ -481,7 +473,7 @@ describe('selectFrom tests', () => {
           rule: 'pick',
         },
       ],
-      selectableVerifiableCredentials: [
+      verifiableCredential: [
         {
           comment: 'IN REALWORLD VPs, THIS WILL BE A BIG UGLY OBJECT INSTEAD OF THE DECODED JWT PAYLOAD THAT FOLLOWS',
           vc: {
@@ -654,13 +646,13 @@ describe('selectFrom tests', () => {
       matches: [
         {
           from: ['B'],
-          matches: ['$.selectableVerifiableCredentials[0]', '$.selectableVerifiableCredentials[1]'],
+          matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
           max: 2,
           name: 'Submission of educational transcripts',
           rule: 'pick',
         },
       ],
-      selectableVerifiableCredentials: [
+      verifiableCredential: [
         {
           '@context': 'https://business-standards.org/schemas/employment-history.json',
           credentialSubject: {
@@ -812,18 +804,14 @@ describe('selectFrom tests', () => {
           from_nested: [
             {
               from: ['A'],
-              matches: [
-                '$.selectableVerifiableCredentials[0]',
-                '$.selectableVerifiableCredentials[1]',
-                '$.selectableVerifiableCredentials[2]',
-              ],
+              matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
               from: ['B'],
-              matches: ['$.selectableVerifiableCredentials[1]', '$.selectableVerifiableCredentials[2]'],
+              matches: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
             },
@@ -833,7 +821,7 @@ describe('selectFrom tests', () => {
           rule: 'all',
         },
       ],
-      selectableVerifiableCredentials: [
+      verifiableCredential: [
         {
           comment: 'IN REALWORLD VPs, THIS WILL BE A BIG UGLY OBJECT INSTEAD OF THE DECODED JWT PAYLOAD THAT FOLLOWS',
           vc: {
@@ -1008,18 +996,14 @@ describe('selectFrom tests', () => {
           from_nested: [
             {
               from: ['A'],
-              matches: [
-                '$.selectableVerifiableCredentials[0]',
-                '$.selectableVerifiableCredentials[1]',
-                '$.selectableVerifiableCredentials[2]',
-              ],
+              matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
               from: ['B'],
-              matches: ['$.selectableVerifiableCredentials[1]', '$.selectableVerifiableCredentials[2]'],
+              matches: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
             },
@@ -1030,7 +1014,7 @@ describe('selectFrom tests', () => {
           rule: 'pick',
         },
       ],
-      selectableVerifiableCredentials: [
+      verifiableCredential: [
         {
           comment: 'IN REALWORLD VPs, THIS WILL BE A BIG UGLY OBJECT INSTEAD OF THE DECODED JWT PAYLOAD THAT FOLLOWS',
           vc: {
@@ -1205,18 +1189,14 @@ describe('selectFrom tests', () => {
           from_nested: [
             {
               from: ['A'],
-              matches: [
-                '$.selectableVerifiableCredentials[0]',
-                '$.selectableVerifiableCredentials[1]',
-                '$.selectableVerifiableCredentials[2]',
-              ],
+              matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
               from: ['B'],
-              matches: ['$.selectableVerifiableCredentials[1]', '$.selectableVerifiableCredentials[2]'],
+              matches: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
             },
@@ -1227,7 +1207,7 @@ describe('selectFrom tests', () => {
           rule: 'pick',
         },
       ],
-      selectableVerifiableCredentials: [
+      verifiableCredential: [
         {
           comment: 'IN REALWORLD VPs, THIS WILL BE A BIG UGLY OBJECT INSTEAD OF THE DECODED JWT PAYLOAD THAT FOLLOWS',
           vc: {
@@ -1400,13 +1380,13 @@ describe('selectFrom tests', () => {
       matches: [
         {
           from: ['B'],
-          matches: ['$.selectableVerifiableCredentials[0]', '$.selectableVerifiableCredentials[1]'],
+          matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
           min: 3,
           name: 'Submission of educational transcripts',
           rule: 'pick',
         },
       ],
-      selectableVerifiableCredentials: [
+      verifiableCredential: [
         {
           '@context': 'https://business-standards.org/schemas/employment-history.json',
           credentialSubject: {
@@ -1556,13 +1536,13 @@ describe('selectFrom tests', () => {
       matches: [
         {
           from: ['B'],
-          matches: ['$.selectableVerifiableCredentials[0]', '$.selectableVerifiableCredentials[1]'],
+          matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
           max: 1,
           name: 'Submission of educational transcripts',
           rule: 'pick',
         },
       ],
-      selectableVerifiableCredentials: [
+      verifiableCredential: [
         {
           '@context': 'https://business-standards.org/schemas/employment-history.json',
           credentialSubject: {
@@ -1713,12 +1693,12 @@ describe('selectFrom tests', () => {
         {
           count: 1,
           from: ['B'],
-          matches: ['$.selectableVerifiableCredentials[0]', '$.selectableVerifiableCredentials[1]'],
+          matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
           name: 'Submission of educational transcripts',
           rule: 'pick',
         },
       ],
-      selectableVerifiableCredentials: [
+      verifiableCredential: [
         {
           '@context': 'https://business-standards.org/schemas/employment-history.json',
           credentialSubject: {
@@ -1868,12 +1848,12 @@ describe('selectFrom tests', () => {
       matches: [
         {
           from: ['B'],
-          matches: ['$.selectableVerifiableCredentials[0]', '$.selectableVerifiableCredentials[1]'],
+          matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
           name: 'Submission of educational transcripts',
           rule: 'all',
         },
       ],
-      selectableVerifiableCredentials: [
+      verifiableCredential: [
         {
           '@context': 'https://business-standards.org/schemas/employment-history.json',
           credentialSubject: {
@@ -2025,18 +2005,14 @@ describe('selectFrom tests', () => {
           from_nested: [
             {
               from: ['A'],
-              matches: [
-                '$.selectableVerifiableCredentials[0]',
-                '$.selectableVerifiableCredentials[1]',
-                '$.selectableVerifiableCredentials[2]',
-              ],
+              matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
               from: ['B'],
-              matches: ['$.selectableVerifiableCredentials[1]', '$.selectableVerifiableCredentials[2]'],
+              matches: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
             },
@@ -2047,7 +2023,7 @@ describe('selectFrom tests', () => {
           rule: 'pick',
         },
       ],
-      selectableVerifiableCredentials: [
+      verifiableCredential: [
         {
           comment: 'IN REALWORLD VPs, THIS WILL BE A BIG UGLY OBJECT INSTEAD OF THE DECODED JWT PAYLOAD THAT FOLLOWS',
           vc: {
@@ -2221,18 +2197,14 @@ describe('selectFrom tests', () => {
           from_nested: [
             {
               from: ['A'],
-              matches: [
-                '$.selectableVerifiableCredentials[0]',
-                '$.selectableVerifiableCredentials[1]',
-                '$.selectableVerifiableCredentials[2]',
-              ],
+              matches: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
               from: ['B'],
-              matches: ['$.selectableVerifiableCredentials[1]', '$.selectableVerifiableCredentials[2]'],
+              matches: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
             },
@@ -2243,7 +2215,7 @@ describe('selectFrom tests', () => {
           max: 1,
         },
       ],
-      selectableVerifiableCredentials: [
+      verifiableCredential: [
         {
           comment: 'IN REALWORLD VPs, THIS WILL BE A BIG UGLY OBJECT INSTEAD OF THE DECODED JWT PAYLOAD THAT FOLLOWS',
           vc: {
@@ -2328,7 +2300,7 @@ describe('selectFrom tests', () => {
     expect(result!.matches![0]).toEqual({
       name: "EU Driver's License",
       rule: 'all',
-      matches: ['$.selectableVerifiableCredentials[0]'],
+      matches: ['$.verifiableCredential[0]'],
     });
   });
 

--- a/test/evaluation/selectFrom.spec.ts
+++ b/test/evaluation/selectFrom.spec.ts
@@ -119,7 +119,11 @@ describe('selectFrom tests', () => {
       matches: [
         {
           from: ['A'],
-          matches: ['$[0]', '$[1]', '$[2]'],
+          matches: [
+            '$.selectableVerifiableCredentials[0]',
+            '$.selectableVerifiableCredentials[1]',
+            '$.selectableVerifiableCredentials[2]',
+          ],
           name: 'Submission of educational transcripts',
           rule: 'all',
         },
@@ -297,7 +301,7 @@ describe('selectFrom tests', () => {
       matches: [
         {
           from: ['B'],
-          matches: ['$[0]', '$[1]'],
+          matches: ['$.selectableVerifiableCredentials[0]', '$.selectableVerifiableCredentials[1]'],
           min: 2,
           name: 'Submission of educational transcripts',
           rule: 'pick',
@@ -456,14 +460,18 @@ describe('selectFrom tests', () => {
           from_nested: [
             {
               from: ['A'],
-              matches: ['$[0]', '$[1]', '$[2]'],
+              matches: [
+                '$.selectableVerifiableCredentials[0]',
+                '$.selectableVerifiableCredentials[1]',
+                '$.selectableVerifiableCredentials[2]',
+              ],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
               from: ['B'],
-              matches: ['$[1]', '$[2]'],
+              matches: ['$.selectableVerifiableCredentials[1]', '$.selectableVerifiableCredentials[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
             },
@@ -646,7 +654,7 @@ describe('selectFrom tests', () => {
       matches: [
         {
           from: ['B'],
-          matches: ['$[0]', '$[1]'],
+          matches: ['$.selectableVerifiableCredentials[0]', '$.selectableVerifiableCredentials[1]'],
           max: 2,
           name: 'Submission of educational transcripts',
           rule: 'pick',
@@ -804,14 +812,18 @@ describe('selectFrom tests', () => {
           from_nested: [
             {
               from: ['A'],
-              matches: ['$[0]', '$[1]', '$[2]'],
+              matches: [
+                '$.selectableVerifiableCredentials[0]',
+                '$.selectableVerifiableCredentials[1]',
+                '$.selectableVerifiableCredentials[2]',
+              ],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
               from: ['B'],
-              matches: ['$[1]', '$[2]'],
+              matches: ['$.selectableVerifiableCredentials[1]', '$.selectableVerifiableCredentials[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
             },
@@ -996,14 +1008,18 @@ describe('selectFrom tests', () => {
           from_nested: [
             {
               from: ['A'],
-              matches: ['$[0]', '$[1]', '$[2]'],
+              matches: [
+                '$.selectableVerifiableCredentials[0]',
+                '$.selectableVerifiableCredentials[1]',
+                '$.selectableVerifiableCredentials[2]',
+              ],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
               from: ['B'],
-              matches: ['$[1]', '$[2]'],
+              matches: ['$.selectableVerifiableCredentials[1]', '$.selectableVerifiableCredentials[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
             },
@@ -1189,14 +1205,18 @@ describe('selectFrom tests', () => {
           from_nested: [
             {
               from: ['A'],
-              matches: ['$[0]', '$[1]', '$[2]'],
+              matches: [
+                '$.selectableVerifiableCredentials[0]',
+                '$.selectableVerifiableCredentials[1]',
+                '$.selectableVerifiableCredentials[2]',
+              ],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
               from: ['B'],
-              matches: ['$[1]', '$[2]'],
+              matches: ['$.selectableVerifiableCredentials[1]', '$.selectableVerifiableCredentials[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
             },
@@ -1380,7 +1400,7 @@ describe('selectFrom tests', () => {
       matches: [
         {
           from: ['B'],
-          matches: ['$[0]', '$[1]'],
+          matches: ['$.selectableVerifiableCredentials[0]', '$.selectableVerifiableCredentials[1]'],
           min: 3,
           name: 'Submission of educational transcripts',
           rule: 'pick',
@@ -1536,7 +1556,7 @@ describe('selectFrom tests', () => {
       matches: [
         {
           from: ['B'],
-          matches: ['$[0]', '$[1]'],
+          matches: ['$.selectableVerifiableCredentials[0]', '$.selectableVerifiableCredentials[1]'],
           max: 1,
           name: 'Submission of educational transcripts',
           rule: 'pick',
@@ -1693,7 +1713,7 @@ describe('selectFrom tests', () => {
         {
           count: 1,
           from: ['B'],
-          matches: ['$[0]', '$[1]'],
+          matches: ['$.selectableVerifiableCredentials[0]', '$.selectableVerifiableCredentials[1]'],
           name: 'Submission of educational transcripts',
           rule: 'pick',
         },
@@ -1848,7 +1868,7 @@ describe('selectFrom tests', () => {
       matches: [
         {
           from: ['B'],
-          matches: ['$[0]', '$[1]'],
+          matches: ['$.selectableVerifiableCredentials[0]', '$.selectableVerifiableCredentials[1]'],
           name: 'Submission of educational transcripts',
           rule: 'all',
         },
@@ -2005,14 +2025,18 @@ describe('selectFrom tests', () => {
           from_nested: [
             {
               from: ['A'],
-              matches: ['$[0]', '$[1]', '$[2]'],
+              matches: [
+                '$.selectableVerifiableCredentials[0]',
+                '$.selectableVerifiableCredentials[1]',
+                '$.selectableVerifiableCredentials[2]',
+              ],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
               from: ['B'],
-              matches: ['$[1]', '$[2]'],
+              matches: ['$.selectableVerifiableCredentials[1]', '$.selectableVerifiableCredentials[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
             },
@@ -2197,14 +2221,18 @@ describe('selectFrom tests', () => {
           from_nested: [
             {
               from: ['A'],
-              matches: ['$[0]', '$[1]', '$[2]'],
+              matches: [
+                '$.selectableVerifiableCredentials[0]',
+                '$.selectableVerifiableCredentials[1]',
+                '$.selectableVerifiableCredentials[2]',
+              ],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
               from: ['B'],
-              matches: ['$[1]', '$[2]'],
+              matches: ['$.selectableVerifiableCredentials[1]', '$.selectableVerifiableCredentials[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
             },
@@ -2300,7 +2328,7 @@ describe('selectFrom tests', () => {
     expect(result!.matches![0]).toEqual({
       name: "EU Driver's License",
       rule: 'all',
-      matches: ['$[0]'],
+      matches: ['$.selectableVerifiableCredentials[0]'],
     });
   });
 

--- a/test/evaluation/submissionFrom.spec.ts
+++ b/test/evaluation/submissionFrom.spec.ts
@@ -34,9 +34,9 @@ describe('Submission requirements tests', () => {
       expect.objectContaining({
         definition_id: '32f54163-7166-48f1-93d8-ff217bdb0653',
         descriptor_map: [
-          { format: 'ldp_vc', id: 'Educational transcripts', path: '$[0]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$[1]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$[2]' },
+          { format: 'ldp_vc', id: 'Educational transcripts', path: '$.verifiableCredential[0]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$.verifiableCredential[1]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$.verifiableCredential[2]' },
         ],
       })
     );
@@ -62,8 +62,8 @@ describe('Submission requirements tests', () => {
       expect.objectContaining({
         definition_id: '32f54163-7166-48f1-93d8-ff217bdb0653',
         descriptor_map: [
-          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$[1]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$[2]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$.verifiableCredential[1]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$.verifiableCredential[2]' },
         ],
       })
     );
@@ -90,8 +90,8 @@ describe('Submission requirements tests', () => {
       expect.objectContaining({
         definition_id: '32f54163-7166-48f1-93d8-ff217bdb0653',
         descriptor_map: [
-          { format: 'ldp_vc', id: 'Educational transcripts', path: '$[0]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$[1]' },
+          { format: 'ldp_vc', id: 'Educational transcripts', path: '$.verifiableCredential[0]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$.verifiableCredential[1]' },
         ],
       })
     );
@@ -117,8 +117,8 @@ describe('Submission requirements tests', () => {
       expect.objectContaining({
         definition_id: '32f54163-7166-48f1-93d8-ff217bdb0653',
         descriptor_map: [
-          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$[1]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$[2]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$.verifiableCredential[1]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$.verifiableCredential[2]' },
         ],
       })
     );
@@ -212,9 +212,9 @@ describe('Submission requirements tests', () => {
       expect.objectContaining({
         definition_id: '32f54163-7166-48f1-93d8-ff217bdb0653',
         descriptor_map: [
-          { format: 'ldp_vc', id: 'Educational transcripts', path: '$[0]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$[1]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$[2]' },
+          { format: 'ldp_vc', id: 'Educational transcripts', path: '$.verifiableCredential[0]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$.verifiableCredential[1]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$.verifiableCredential[2]' },
         ],
       })
     );
@@ -240,9 +240,9 @@ describe('Submission requirements tests', () => {
       expect.objectContaining({
         definition_id: '32f54163-7166-48f1-93d8-ff217bdb0653',
         descriptor_map: [
-          { format: 'ldp_vc', id: 'Educational transcripts', path: '$[0]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$[1]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$[2]' },
+          { format: 'ldp_vc', id: 'Educational transcripts', path: '$.verifiableCredential[0]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$.verifiableCredential[1]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$.verifiableCredential[2]' },
         ],
       })
     );
@@ -268,9 +268,9 @@ describe('Submission requirements tests', () => {
       expect.objectContaining({
         definition_id: '32f54163-7166-48f1-93d8-ff217bdb0653',
         descriptor_map: [
-          { format: 'ldp_vc', id: 'Educational transcripts', path: '$[0]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$[1]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$[2]' },
+          { format: 'ldp_vc', id: 'Educational transcripts', path: '$.verifiableCredential[0]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$.verifiableCredential[1]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$.verifiableCredential[2]' },
         ],
       })
     );

--- a/test/evaluation/submissionRequirements.spec.ts
+++ b/test/evaluation/submissionRequirements.spec.ts
@@ -33,9 +33,9 @@ describe('Submission requirements tests', () => {
       expect.objectContaining({
         definition_id: '32f54163-7166-48f1-93d8-ff217bdb0653',
         descriptor_map: [
-          { format: 'ldp_vc', id: 'Educational transcripts', path: '$[0]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$[1]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$[2]' },
+          { format: 'ldp_vc', id: 'Educational transcripts', path: '$.verifiableCredential[0]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$.verifiableCredential[1]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$.verifiableCredential[2]' },
         ],
       })
     );
@@ -56,8 +56,8 @@ describe('Submission requirements tests', () => {
       expect.objectContaining({
         definition_id: '32f54163-7166-48f1-93d8-ff217bdb0653',
         descriptor_map: [
-          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$[1]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$[2]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$.verifiableCredential[1]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$.verifiableCredential[2]' },
         ],
       })
     );
@@ -98,8 +98,8 @@ describe('Submission requirements tests', () => {
       expect.objectContaining({
         definition_id: '32f54163-7166-48f1-93d8-ff217bdb0653',
         descriptor_map: [
-          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$[1]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$[2]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$.verifiableCredential[1]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$.verifiableCredential[2]' },
         ],
       })
     );
@@ -188,9 +188,9 @@ describe('Submission requirements tests', () => {
       expect.objectContaining({
         definition_id: '32f54163-7166-48f1-93d8-ff217bdb0653',
         descriptor_map: [
-          { format: 'ldp_vc', id: 'Educational transcripts', path: '$[0]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$[1]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$[2]' },
+          { format: 'ldp_vc', id: 'Educational transcripts', path: '$.verifiableCredential[0]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$.verifiableCredential[1]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$.verifiableCredential[2]' },
         ],
       })
     );
@@ -215,9 +215,9 @@ describe('Submission requirements tests', () => {
       expect.objectContaining({
         definition_id: '32f54163-7166-48f1-93d8-ff217bdb0653',
         descriptor_map: [
-          { format: 'ldp_vc', id: 'Educational transcripts', path: '$[0]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$[1]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$[2]' },
+          { format: 'ldp_vc', id: 'Educational transcripts', path: '$.verifiableCredential[0]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$.verifiableCredential[1]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$.verifiableCredential[2]' },
         ],
       })
     );
@@ -242,9 +242,9 @@ describe('Submission requirements tests', () => {
       expect.objectContaining({
         definition_id: '32f54163-7166-48f1-93d8-ff217bdb0653',
         descriptor_map: [
-          { format: 'ldp_vc', id: 'Educational transcripts', path: '$[0]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$[1]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$[2]' },
+          { format: 'ldp_vc', id: 'Educational transcripts', path: '$.verifiableCredential[0]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$.verifiableCredential[1]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$.verifiableCredential[2]' },
         ],
       })
     );

--- a/test/pejs.spec.ts
+++ b/test/pejs.spec.ts
@@ -2,8 +2,7 @@ import fs from 'fs';
 
 import { PresentationDefinition } from '@sphereon/pe-models';
 
-import { PEJS, Presentation, Validated, VerifiablePresentation } from '../lib';
-import { ProofType } from '../lib/types/SSI.types';
+import { PEJS, Presentation, ProofType, Validated, VerifiablePresentation } from '../lib';
 
 import {
   assertedMockCallback,
@@ -61,9 +60,9 @@ describe('evaluate', () => {
       expect.objectContaining({
         definition_id: '32f54163-7166-48f1-93d8-ff217bdb0653',
         descriptor_map: [
-          { format: 'ldp_vc', id: 'Educational transcripts', path: '$[0]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$[1]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$[2]' },
+          { format: 'ldp_vc', id: 'Educational transcripts', path: '$.verifiableCredential[0]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$.verifiableCredential[1]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$.verifiableCredential[2]' },
         ],
       })
     );
@@ -98,9 +97,9 @@ describe('evaluate', () => {
       expect.objectContaining({
         definition_id: '32f54163-7166-48f1-93d8-ff217bdb0653',
         descriptor_map: [
-          { format: 'ldp_vc', id: 'Educational transcripts', path: '$[0]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$[1]' },
-          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$[2]' },
+          { format: 'ldp_vc', id: 'Educational transcripts', path: '$.verifiableCredential[0]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 1', path: '$.verifiableCredential[1]' },
+          { format: 'ldp_vc', id: 'Educational transcripts 2', path: '$.verifiableCredential[2]' },
         ],
       })
     );


### PR DESCRIPTION
### ESSIFI-160
json path for methods `selectFrom`, `presentationFrom`, and `verifiablePresentationFrom` changed

method                                 | ps indexing example | what should be
evaluatePresentation           | path": "$[0]”               | “path": "$.verifiableCredential[0]”
evaluateCredentials             | path": "$[0]”               | “path": "$.verifiableCredential[0]”
selectFrom                           | “matches": ["$[0]"]     | "matches": ["$.selectableVerifiableCredentials[0]"]
presentationFrom                 | "path": "$[0]”             | “path": "$.verifiableCredential[0]”
verifiablePresentationFrom  | “path": "$[0]”             | “path": "$.verifiableCredential[0]”

based on this table, I've changed the return value for this methods.
because we're using the path element heavily in our inner logic, these changes only change the "path" elements at the very last step.

- also changed the name of the `matches` element inside `submissionRequirementMatches` to vc_path
- evaluatePresentation returns a list of verifiableCredentials called `verifiableCredential` just like the other methods
- evaluateCredentials returns a list of verifiableCredentials called `verifiableCredential` just like the other methods
